### PR TITLE
fixed attribute is not in "msg"

### DIFF
--- a/xmppgcm/gcm.py
+++ b/xmppgcm/gcm.py
@@ -103,7 +103,7 @@ class GCM(ClientXMPP):
                 self.connecton_draining = True
 
         elif data.message_type == GCMMessageType.RECEIPT:
-            logging.debug('Received Receipts for message_id: %s' % msg.message_id)
+            logging.debug('Received Receipts for message_id: %s' % data.message_id)
             self.event(XMPPEvent.RECEIPT, data)
 
         else:


### PR DESCRIPTION
```
ERROR:sleekxmpp.basexmpp:'Message' object has no attribute 'message_id'
Traceback (most recent call last):
  File "C:\env\chat\lib\site-packages\sleekxmpp\xmlstream\xmlstream.py", line 1675, in _event_runner
    handler.run(args[0])
  File "C:\env\chat\lib\site-packages\sleekxmpp\xmlstream\handler\callback.py", line 76, in run
    self._pointer(payload)
  File "C:\env\chat\lib\site-packages\xmppgcm\gcm.py", line 106, in on_gcm_message
    logging.debug('Received Receipts for message_id: %s' % msg.message_id)
AttributeError: 'Message' object has no attribute 'message_id'
```
