### PR TITLE
Fixed upstream message support. Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # xmppgcm
 
-xmppgcm is python client for Google (Firebase) Cloud Messaging using XMPP protocol. At the time of writing this, there is no similar library available in pypi repository. Technically this library supports both upstream and downstream messages. But I have not verified upstream messages. Currently the scope is limited to sending messages with device token and topic. [Topic conditions or device groups] are not supported. If anyone is interested to contribute kindly send pull request.
+xmppgcm is Python (2.x/3.x) client for Firebase/Google Cloud Messaging (FCM/GCM) using the XMPP protocol. This library supports both upstream and downstream messaging. Currently, the scope is limited to sending messages with device registration tokens and topics. [Topic conditions or device groups] are not supported.
 
 ### Before you start
-  - [Check GCM XMPP]
+  - [Firebase Cloud Messaging with XMPP]
   - [SleekXMPP]
 
-> This library uses event based mechanism similar to what JavaScript does
 
 ### Events
 
+This library is event-based, similar to Javascript.
+
 All supported events are available in XMPPEvent class:
 
-* XMPPEvent.CONNECTED - event when session is started
-* XMPPEvent.DISCONNECTED - event when connection is closed
-* XMPPEvent.RECEIPT - called if you have requested for message receipt while sending message
-* XMPPEvent.MESSAGE - called when an upstream message received from GCM XMPP server (I have not tested this feature)
+* XMPPEvent.CONNECTED - Triggered when session is opened
+* XMPPEvent.DISCONNECTED - Triggered when connection is closed
+* XMPPEvent.RECEIPT - Triggered when a delivery receipt is received from FCM/GCM
+* XMPPEvent.MESSAGE - Tiggered when an upstream message is received from another device via FCM/GCM
 
-### Send Message to GCM server
+### Send Message to FCM/GCM server
 ```sh
-xmpp.send_gcm('your_device_token', data, options, onAcknowledge)
+xmpp.send_gcm('device_registration_token', data, options, onAcknowledge)
 ```
-Options is a dictionary where you can give [GCM supported options]
+`options` is a dictionary where you can supply [options supported by GCM]
 
 ### Installation
 
@@ -30,53 +31,50 @@ pip install xmppgcm
 ### Sample code
 
 ```sh
+import logging
 from xmppgcm import GCM, XMPPEvent
 
-def onAcknowledge(error, message_id, _from):
+def onAcknowledge(error, message):
+    message_id = message.data['message_id']
+    message_from = message.data['from']
 	if error != None:
-		print 'not acknowledged by GCM'
-	print 'id - {0} : from - {1}'.format(message_id, _from)
+		print('Server did not acknowledge message: ID - {0} : from - {1}'.format(message_id, message_from))
+	print('Server acknowledged message: ID - {0} : from - {1}'.format(message_id, message_from))
 	
+
 def onDisconnect(draining):
-	print 'inside onDisconnect'
+	print('inside onDisconnect')
 	xmpp.connect(('gcm-preprod.googleapis.com', 5236), use_ssl=True)
 
+
 def onSessionStart(queue_length):
-	print 'inside onSessionStart {0}'.format(queue_length)
+	print('inside onSessionStart {0}'.format(queue_length))
 	data = {'key1': 'value1'}
 	options = { 'delivery_receipt_requested': True }
 	xmpp.send_gcm('your_device_token', data, options, onAcknowledge)
 
+
 def onReceipt(data):
-	print 'inside onReceipt {0}'.format(data)
+	print('inside onReceipt {0}'.format(data))
+
 
 def onMessage(data):
-	print 'inside onSessionStart {0}'.format(data)
+	print('inside onSessionStart {0}'.format(data))
 
+
+# optionally, set up logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)-8s %(message)s')
 logging.debug("Starting up")
 
-xmpp = GCM('your_project_id@gcm.googleapis.com', 'gcm_api_key')
+xmpp = GCM('your_sender_id@gcm.googleapis.com', 'fcm_server_key')
 xmpp.add_event_handler(XMPPEvent.CONNECTED, onSessionStart)
 xmpp.add_event_handler(XMPPEvent.DISCONNECTED, onDisconnect)
 xmpp.add_event_handler(XMPPEvent.RECEIPT, onReceipt)
 xmpp.add_event_handler(XMPPEvent.MESSAGE, onMessage)
-
-xmpp.connect(('gcm-preprod.googleapis.com', 5236), use_ssl=True) #test environment
-# xmpp.connect(('gcm-xmpp.googleapis.com', 5235), use_ssl=True)  #prod environment
-
-while True:
-    xmpp.process(block=True)
+xmpp.connect(('fcm-xmpp.googleapis.com', 5236), use_ssl=True) # test environment
+# xmpp.connect(('fcm-xmpp.googleapis.com', 5235), use_ssl=True)  # production environment
+xmpp.process(block=True)
     
-if __name__ == '__main__':
-	_pass
-```
-
-For library logging put following in your code
-```sh
-logging.basicConfig(level=logging.DEBUG, format='%(levelname)-8s %(message)s')
-logging.debug("Starting up")
-
 ```
 
 ### Todos
@@ -96,7 +94,7 @@ Apache License 2.0
 [//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. There is no need to format nicely because it shouldn't be seen. Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
 
 
-   [Check GCM XMPP]: <https://firebase.google.com/docs/cloud-messaging/server#implementing-the-xmpp-connection-server-protocol>
+   [Firebase Cloud Messaging with XMPP]: <https://firebase.google.com/docs/cloud-messaging/server#implementing-the-xmpp-connection-server-protocol>
    [SleekXMPP]: <http://sleekxmpp.com/getting_started/echobot.html>
    [Topic conditions or device groups]: <https://firebase.google.com/docs/cloud-messaging/send-message>
-   [GCM supported options]: <https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref>
+   [options supported by GCM]: <https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref>


### PR DESCRIPTION
I re-factored send_gcm() and created send_gcm_ack() to fix upstream messaging. My changes were added in a way that should not break any existing user's applications.

I also updated the README. The example in the README now supports both Python 2 and Python 3. I also changed some grammar around, removed some things, and referenced Firebase more, since GCM is technically deprecated.